### PR TITLE
chore: add example env template

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,12 @@
+# Supabase
+VITE_SUPABASE_URL=https://your-project.supabase.co
+VITE_SUPABASE_ANON_KEY=your-anon-key
+
+# OpenAI
+VITE_OPENAI_API_KEY=sk-your-openai-api-key
+
+# Stripe
+VITE_STRIPE_PUBLIC_KEY=pk_test_your-stripe-publishable-key
+
+# Optional: Google OAuth
+VITE_GOOGLE_CLIENT_ID=your-google-client-id


### PR DESCRIPTION
## Summary
- add a `.env.example` template with Supabase, OpenAI, Stripe, and optional Google OAuth placeholders
- align the onboarding flow with the README step that copies `.env.example` to a local env file

## Testing
- not run (documentation-only change)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_692a3dd25614832ea8adaf34c4b39178)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds `.env.example` with placeholders for Supabase, OpenAI, Stripe, and optional Google OAuth credentials.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 95ac98fa6ff6431ed948b2395d3f235d04ba3020. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->