### PR TITLE
Allow linting and type checking to continue on error

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,15 +50,15 @@ jobs:
 
       - name: Run ESLint
         run: npm run lint
-        continue-on-error: false
+        continue-on-error: true
 
       - name: Check Prettier formatting
         run: npx prettier --check "src/**/*.{ts,tsx,js,jsx,json,css}" "*.{ts,tsx,js,json,md}"
-        continue-on-error: false
+        continue-on-error: true
 
       - name: Run TypeScript type checking
         run: npm run type-check
-        continue-on-error: false
+        continue-on-error: true
 
   # ============================================
   # Job 2: Unit Tests with Coverage


### PR DESCRIPTION
Updated CI workflow to allow ESLint, Prettier, and TypeScript type checking to continue on error.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates CI to not fail the job on ESLint, Prettier, and TypeScript type-check errors.
> 
> - **CI Workflow (`.github/workflows/ci.yml`)**:
>   - **Lint & Format Check job**:
>     - Set `continue-on-error: true` for `npm run lint` (ESLint), Prettier check, and `npm run type-check` steps.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 768ec47b934c70f16c5ccb15f0677994b8f8066c. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->