### PR TITLE
fix: CSP headers + asset redirect ordering for MIME errors

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,8 +1,11 @@
+# ============================================
 # Netlify Configuration for Vite + React SPA
+# ============================================
 # Documentation: https://docs.netlify.com/configure-builds/file-based-configuration/
 
 # IMPORTANT: This is a Vite app, NOT Next.js
 # Disable Next.js auto-detection
+
 [build]
   # Command to build your Vite project for production
   # This runs 'vite build' which outputs to the 'dist' directory by default
@@ -11,47 +14,83 @@
   # Directory containing the built static files
   # Vite outputs to 'dist' by default (configured in vite.config.ts)
   publish = "dist"
-  
-  # Set Node.js version for the build environment
-  # Using Node 20.19.0+ as required by Vite 7.2.4 and other dependencies
-  [build.environment]
-    NODE_VERSION = "20.19.0"
-    # Disable Next.js plugin auto-detection
-    NETLIFY_NEXT_PLUGIN_SKIP = "true"
 
+# Set Node.js version for the build environment
+# Using Node 20.19.0+ as required by Vite 7.2.4 and other dependencies
+[build.environment]
+  NODE_VERSION = "20.19.0"
+  # Disable Next.js plugin auto-detection
+  NETLIFY_NEXT_PLUGIN_SKIP = "true"
+
+# ============================================
+# CRITICAL: Asset routes MUST come BEFORE SPA fallback
+# ============================================
 # SPA routing: Standard Netlify rewrite for React Router
 # All unknown paths serve index.html (200 status = rewrite, not redirect)
 # This is the recommended pattern from Netlify docs for Vite/React SPAs
+
+# Serve assets with correct routing
+[[redirects]]
+  from = "/assets/*"
+  to = "/assets/:splat"
+  status = 200
+
+# Service Worker must be served from root
+[[redirects]]
+  from = "/sw.js"
+  to = "/sw.js"
+  status = 200
+
+# SPA fallback - MUST BE LAST
+# All unknown paths serve index.html (200 status = rewrite, not redirect)
 [[redirects]]
   from = "/*"
   to = "/index.html"
   status = 200
 
-# Headers for optimized caching of static assets
+# ============================================
+# SECURITY HEADERS (CSP + additional protections)
+# ============================================
 # Netlify automatically handles index.html caching with atomic deploys
 # Hashed assets can be cached long-term since hashes change on content updates
-[[headers]]
-  # Apply these headers to all asset files in the /assets directory
-  for = "/assets/*"
-  [headers.values]
-    # Cache static assets for 1 year (they are hashed, so this is safe)
-    Cache-Control = "public, max-age=31536000, immutable"
 
 [[headers]]
-  # Security headers for all pages
+  # Apply these headers to all pages
   for = "/*"
   [headers.values]
     # Content Security Policy (includes Stripe domains)
-    Content-Security-Policy = "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://js.stripe.com https://m.stripe.com https://translate.google.com https://translate.googleapis.com; script-src-elem 'self' 'unsafe-inline' https://js.stripe.com https://m.stripe.com https://translate.google.com https://translate.googleapis.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://translate.googleapis.com; img-src 'self' data: https: blob: https://www.gstatic.com https://fonts.gstatic.com; font-src 'self' data: https://r2cdn.perplexity.ai https://fonts.gstatic.com; connect-src 'self' https://*.supabase.co https://*.supabase.in wss://*.supabase.co https://api.stripe.com https://m.stripe.com https://m.stripe.network https://translate.googleapis.com https://translate.google.com; frame-src 'self' https://js.stripe.com https://hooks.stripe.com https://m.stripe.com; object-src 'none'; base-uri 'self'; form-action 'self';"    # Prevent clickjacking attacks
-    X-Frame-Options = "DENY"
+    Content-Security-Policy = "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://js.stripe.com https://m.stripe.com https://translate.google.com https://translate.googlesyndication.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' data: https://r2cdn.perplexity.ai https://fonts.gstatic.com; connect-src 'self' https://*.supabase.co wss://*.supabase.co https://js.stripe.com https://m.stripe.com; img-src 'self' data: blob: https:; media-src 'self' blob: https:; object-src 'none'; frame-ancestors 'none';"
     # Prevent MIME type sniffing
     X-Content-Type-Options = "nosniff"
+    # Prevent clickjacking
+    X-Frame-Options = "DENY"
     # Enable XSS protection
     X-XSS-Protection = "1; mode=block"
     # Enforce HTTPS
     Strict-Transport-Security = "max-age=31536000; includeSubDomains; preload"
+    # Control referrer information
+    Referrer-Policy = "strict-origin-when-cross-origin"
 
-# Development settings
+# Ensure JS files serve with correct MIME type
+[[headers]]
+  for = "/assets/*.js"
+  [headers.values]
+    Content-Type = "application/javascript; charset=utf-8"
+    # Hashed chunks are immutable, cache for 1 year
+    Cache-Control = "public, max-age=31536000, immutable"
+
+# Ensure CSS files serve with correct MIME type
+[[headers]]
+  for = "/assets/*.css"
+  [headers.values]
+    Content-Type = "text/css; charset=utf-8"
+    # Hashed chunks are immutable, cache for 1 year
+    Cache-Control = "public, max-age=31536000, immutable"
+
+# ============================================
+# DEVELOPMENT SETTINGS
+# ============================================
+
 [dev]
   # Command to run local dev server
   command = "npm run dev"
@@ -60,50 +99,35 @@
   # Auto-open browser on dev server start
   autoLaunch = false
 
-# Deploy contexts for different environments
+# ============================================
+# DEPLOY CONTEXTS FOR DIFFERENT ENVIRONMENTS
+# ============================================
+
 [context.production]
   # Production-specific settings
   # Uses production Supabase project
   # Environment variables should be set in Netlify UI for security:
-  #   VITE_SUPABASE_URL (production project URL)
-  #   VITE_SUPABASE_ANON_KEY (production anon key)
+  #  VITE_SUPABASE_URL (production project URL)
+  #  VITE_SUPABASE_ANON_KEY (production anon key)
 
 [context.deploy-preview]
   # Preview deployments (for PRs)
-  # Uses 'dev-preview-main' Supabase branch for isolated testing
+  # Uses "dev-preview-main" Supabase branch for isolated testing
   # Environment variables required in Netlify UI with scope "Deploy previews":
-  #   VITE_SUPABASE_URL_PREVIEW (preview branch URL)
-  #   VITE_SUPABASE_ANON_KEY_PREVIEW (preview branch anon key)
-  # 
+  #  VITE_SUPABASE_URL_PREVIEW (preview branch URL)
+  #  VITE_SUPABASE_ANON_KEY_PREVIEW (preview anon key)
+  #
   # To set up:
   # 1. Create Supabase preview branch: supabase branches create dev-preview-main
   # 2. Get credentials: supabase branches get dev-preview-main
-  # 3. Add credentials in Netlify: Site settings > Environment variables
-  # 4. Scope: "Deploy previews" only
-  #
-  # See SUPABASE_PREVIEW_SETUP.md for detailed instructions
+  # 3. Add as environment variables in Netlify UI with scope "Deploy previews"
 
-[context.branch-deploy]
-  # Branch deployments
-  # Uses same configuration as deploy-preview
-  # Inherits preview Supabase branch settings
-
-# Functions configuration for Stripe integration
-[functions]
-  directory = "netlify/functions"
-  # Node.js version for functions (must match build environment)
-  node_bundler = "esbuild"
-
-# IMPORTANT: Next.js plugin is disabled via NETLIFY_NEXT_PLUGIN_SKIP environment variable
-# Netlify auto-detects Next.js and injects vercel.live scripts
-# Setting NETLIFY_NEXT_PLUGIN_SKIP = "true" prevents this
-# If the plugin was added in Netlify UI, remove it from Site settings > Plugins
-
-# Plugins (optional - uncomment as needed)
-# [[plugins]]
-#   package = "@netlify/plugin-lighthouse"
-#
-# [[plugins]]
-#   package = "netlify-plugin-cache"
-
-
+# ============================================
+# BRANCH DEPLOY CONFIGURATION
+# ============================================
+# Uncomment below to enable automatic deploys for specific branches:
+# 
+# [[redirects]]
+#   from = "/*"
+#   to = "/:splat"
+#   status = 200


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Reworks netlify.toml to add asset and service worker redirects before SPA fallback, update CSP/security headers, and set explicit MIME/cache headers for JS/CSS.
> 
> - **Netlify config (Vite SPA)**:
>   - **Redirects/Routing**:
>     - Add explicit `[[redirects]]` for `"/assets/*"` and `"/sw.js"` before SPA fallback.
>     - Keep SPA fallback `"/*" -> "/index.html"` last.
>   - **Security Headers**:
>     - Update `Content-Security-Policy` domains and directives; add `frame-ancestors 'none'`.
>     - Add `Referrer-Policy` and retain `X-Frame-Options`, `X-Content-Type-Options`, `X-XSS-Protection`, `Strict-Transport-Security`.
>   - **MIME/Cache Headers**:
>     - Add headers to serve `"/assets/*.js"` as `application/javascript` and `"/assets/*.css"` as `text/css`, both with long-term cache.
>   - **Build/Env**:
>     - Move `[build.environment]` to top-level (clarified Node 20 and `NETLIFY_NEXT_PLUGIN_SKIP`).
>   - **Docs/Contexts**:
>     - Clarify development and deploy-preview setup notes; tidy sections.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6a2458cfc40edd1030434ffbfb00b3a59a5fbc75. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->