### PR TITLE
feat: Add French (fr-CA) localization to Stripe checkout for Quebec c…

### DIFF
--- a/netlify/functions/create-checkout-session.js
+++ b/netlify/functions/create-checkout-session.js
@@ -107,7 +107,8 @@ exports.handler = async (event, context) => {
       mode: 'subscription',
       success_url: `${baseUrl}/premium?success=true&session_id={CHECKOUT_SESSION_ID}`,
       cancel_url: `${baseUrl}/premium?canceled=true`,
-      customer_email: customerEmail,     locale: 'fr-CA',
+      customer_email: customerEmail,
+      locale: 'fr-CA',
       metadata: {
         userId: user.id,
         tier: tier,


### PR DESCRIPTION
…ustomers

- Added `locale: 'fr-CA'` parameter to Stripe checkout session creation in netlify/functions/create-checkout-session.js
- Stripe Checkout will now display the entire checkout experience in French Canadian
- Applies to all Zyeuté subscription tier purchases (bronze, silver, gold)
- Also need to apply same localization to supabase/functions/create-checkout-session/index.ts

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds `locale: 'fr-CA'` to Stripe Checkout session creation to display the checkout in French Canadian.
> 
> - **Payments / Serverless**:
>   - Set `locale: 'fr-CA'` in `netlify/functions/create-checkout-session.js` when creating Stripe Checkout subscription sessions (`stripe.checkout.sessions.create`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 54bcd00c15a4923625ac08d08e635ef73b35f1d5. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->