### PR TITLE
feat: Add French (fr-CA) localization to Supabase checkout function f…

### DIFF
--- a/supabase/functions/create-checkout-session/index.ts
+++ b/supabase/functions/create-checkout-session/index.ts
@@ -97,7 +97,7 @@ serve(async (req) => {
       mode: 'subscription',
       success_url: `${baseUrl}/premium?success=true&session_id={CHECKOUT_SESSION_ID}`,
       cancel_url: `${baseUrl}/premium?canceled=true`,
-      customer_email: customerEmail,
+      customer_email: customerEmail,     locale: 'fr-CA',
       metadata: {
         userId: user.id,
         tier: tier,


### PR DESCRIPTION
…or Quebec

- Added `locale: 'fr-CA'` parameter to Stripe checkout session creation in supabase/functions/create-checkout-session/index.ts
- Ensures consistency with the Netlify function implementation
- Quebec French customers will see the complete checkout experience in French
- Applies to both Netlify and Supabase Edge Function deployments

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add `locale: 'fr-CA'` to Stripe Checkout session creation in `supabase/functions/create-checkout-session/index.ts`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 994a0fb656a16f3a29743155f219ed46477ac7c7. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->